### PR TITLE
Fixed build issue re: missing hb.h

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-image-view
 	pkgdesc = ROS - A simple viewer for ROS image topics.
 	pkgver = 1.13.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/image_view
 	arch = any
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/image_view'
 pkgname='ros-melodic-image-view'
 pkgver='1.13.0'
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(
@@ -73,7 +73,11 @@ build() {
 	/usr/share/ros-build-tools/fix-python-scripts.sh -v 3 ${srcdir}/${_dir}
 
 	# Build the project.
-	cmake ${srcdir}/${_dir} \
+       # Fix issue with missing <hb.h> due to pango changes
+       # Upstream issue: https://github.com/ros-perception/image_pipeline/issues/456
+       export CXXFLAGS="${CXXFLAGS} -isystem /usr/include/harfbuzz"
+
+       cmake ${srcdir}/${_dir} \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCATKIN_BUILD_BINARY_PACKAGE=ON \
 		-DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \


### PR DESCRIPTION
Added an extra step to fix the build process. Fixes #6 
Maybe this issue should be fixed in the package's CMakeLists.txt and patched in instead of the PKGBUILD?